### PR TITLE
Added file type field for object File on server side

### DIFF
--- a/client.js
+++ b/client.js
@@ -212,7 +212,7 @@
 			mtime: file.lastModifiedDate,
 			meta: file.meta,
 			encoding: useText ? "text" : "octet",
-            type: file.type,
+			type: file.type,
 			id: id
 		});
 

--- a/server.js
+++ b/server.js
@@ -231,7 +231,7 @@ function SocketIOFileUploadServer() {
 				name: data.name,
 				mtime: new Date(data.mtime),
 				encoding: data.encoding,
-                type: data.type,
+				type: data.type,
 				clientDetail: {},
 				meta: data.meta || {},
 				id: data.id,


### PR DESCRIPTION
Object File on client side has "type" field which indicate file extension (screenshot from dev tools below).
![siofu-client](https://cloud.githubusercontent.com/assets/4158258/4337310/3878d374-400e-11e4-97c6-0d92cef61919.png)
But on server side object File doesn't have "type" field:
![siofu-server](https://cloud.githubusercontent.com/assets/4158258/4337266/b3d99482-400d-11e4-986a-e8bb940fd938.png)

Via using this field we will be able to handle the file depending on its' type.
