### PR TITLE
Modified filename regex to allow non-roman chars

### DIFF
--- a/server.js
+++ b/server.js
@@ -116,7 +116,9 @@ function SocketIOFileUploadServer() {
 	 */
 	var _findFileName = function(fileInfo, next){
 		// Strip dangerous characters from the file name
-		var filesafeName = fileInfo.name.replace(/[^\w\-\.]/g, "_");
+		var filesafeName = fileInfo.name
+		.replace(/[\/\?<>\\:\*\|":]|[\x00-\x1f\x80-\x9f]|^\.+$/g, "_");
+
 		var ext = path.extname(filesafeName);
 		var base = path.basename(filesafeName, ext);
 


### PR DESCRIPTION
I had a filename that was `06 Не из саду было.mp3` and it came out as `06________________.mp3`, so I've modified the regex to strip off naughty characters specifically rather than whitelisting only roman characters.