### PR TITLE
Replace throw on minor error to log to avoid server crashes, fix #27

### DIFF
--- a/server.js
+++ b/server.js
@@ -156,7 +156,8 @@ function SocketIOFileUploadServer() {
 						if (err) {
 							fileInfo.success = false;
 							_emitComplete(socket, data.id, fileInfo.success);
-							throw err;
+							console.log("SocketIOFileUploadServer Error (_uploadDone fs.utimes):");
+							console.log(err);
 						}
 
 						// Emit the "saved" event to the server-side listeners


### PR DESCRIPTION
Remove unnecessary throw when fs.utime returns an error.