### PR TITLE
Prevent erasing meta object in case it has already been set before the start event

### DIFF
--- a/client.js
+++ b/client.js
@@ -313,7 +313,7 @@
 
 		// Ensure existence of meta property on each file
 		for (var i = 0; i < files.length; i++) {
-			files[i].meta = {};
+			if(!files[i].meta) files[i].meta = {};
 		}
 
 		// Dispatch the "choose" event


### PR DESCRIPTION
If we set the file meta data on the "choose" client event, the meta data will be overwritten.
So, in the loop which create the meta object on each file to ensure the property exists, I added a check.