### PR TITLE
Add final filename to the client details object.

### DIFF
--- a/server.js
+++ b/server.js
@@ -68,7 +68,7 @@ function SocketIOFileUploadServer() {
 	 */
 	var _emitComplete = function (socket, id, success) {
 		var fileInfo = files[id];
-		fileInfo.clientDetail.finalName = fileInfo.pathName.split('/').pop();
+		fileInfo.clientDetail.finalName = path.basename(fileInfo.pathName);
 		socket.emit("siofu_complete", {
 			id: id,
 			success: success,

--- a/server.js
+++ b/server.js
@@ -68,6 +68,7 @@ function SocketIOFileUploadServer() {
 	 */
 	var _emitComplete = function (socket, id, success) {
 		var fileInfo = files[id];
+		fileInfo.clientDetail.finalName = fileInfo.pathName.split('/').pop();
 		socket.emit("siofu_complete", {
 			id: id,
 			success: success,


### PR DESCRIPTION
Currently, if multiple users upload a file with the same name, there is no way on the client to know what the final filename is. This adds the actual filename as saved to the clientDetail object.